### PR TITLE
Bugfix #176817876 – Allow to plug in client behaviour when the view changes

### DIFF
--- a/src/Anatomogram.js
+++ b/src/Anatomogram.js
@@ -32,7 +32,7 @@ class Anatomogram extends React.Component {
       showIds: [],
       selectIds: [],
       highlightIds:[]
-    })
+    }, this.props.afterSwitchView(species, anatomogramView))
   }
 
   static getDerivedStateFromProps(props, state) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -88,7 +88,8 @@ const normaliseSpecies = mapProps(
 const addDefaultCallbacks = defaultProps({
   onMouseOver: () => {},
   onMouseOut: () => {},
-  onClick: () => {}
+  onClick: () => {},
+  afterSwitchView: () => {}
 })
 
 const definePropTypes = setPropTypes({


### PR DESCRIPTION
Add a new callback that is run when the view within an anatomogram changes.